### PR TITLE
Bypass watchdog for long dns resolution

### DIFF
--- a/esphome/components/wireguard/wireguard.cpp
+++ b/esphome/components/wireguard/wireguard.cpp
@@ -174,35 +174,16 @@ void Wireguard::start_connection_() {
   }
 
   ESP_LOGD(TAG, "starting WireGuard connection...");
-  
-  // The following function can take longer than the 5 seconds timeout of WDT
-#if defined(USE_ESP_IDF)
-#if ESP_IDF_VERSION_MAJOR >= 5
-  esp_task_wdt_config_t wdtc;
-  wdtc.timeout_ms = 15000;
-  wdtc.idle_core_mask = 0;
-  wdtc.trigger_panic = false;
-  esp_task_wdt_reconfigure(&wdtc);
-#else
-  esp_task_wdt_init(15, false);
-#endif
-#elif defined(USE_ARDUINO)
-  disableLoopWDT();
-#endif
 
+  /*
+   * The function esp_wireguard_connect() contains a DNS resolution
+   * that could trigger the watchdog, so before it we suspend (or
+   * increase the time, it depends on the platform) the wdt and
+   * then we resume the normal timeout.
+   */
+  suspend_wdt();
   this->wg_connected_ = esp_wireguard_connect(&(this->wg_ctx_));
-
-  // Set the WDT back to the configured timeout
-#if defined(USE_ESP_IDF)
-#if ESP_IDF_VERSION_MAJOR >= 5
-  wdtc.timeout_ms = CONFIG_ESP_TASK_WDT_TIMEOUT_S;
-  esp_task_wdt_reconfigure(&wdtc);
-#else
-  esp_task_wdt_init(CONFIG_ESP_TASK_WDT_TIMEOUT_S, false);
-#endif
-#elif defined(USE_ARDUINO)
-  enableLoopWDT();
-#endif
+  resume_wdt();
 
   if (this->wg_connected_ == ESP_OK) {
     ESP_LOGI(TAG, "WireGuard connection started");
@@ -225,6 +206,41 @@ void Wireguard::start_connection_() {
     this->on_shutdown();
     this->mark_failed();
   }
+}
+
+void suspend_wdt() {
+#if defined(USE_ESP_IDF)
+#if ESP_IDF_VERSION_MAJOR >= 5
+  ESP_LOGV(TAG, "temporarily increasing wdt timeout to 15000 ms");
+  esp_task_wdt_config_t wdtc;
+  wdtc.timeout_ms = 15000;
+  wdtc.idle_core_mask = 0;
+  wdtc.trigger_panic = false;
+  esp_task_wdt_reconfigure(&wdtc);
+#else
+  ESP_LOGV(TAG, "temporarily increasing wdt timeout to 15 seconds");
+  esp_task_wdt_init(15, false);
+#endif
+#elif defined(USE_ARDUINO)
+  ESP_LOGV(TAG, "temporarily disabling the wdt");
+  disableLoopWDT();
+#endif
+}
+
+void resume_wdt() {
+#if defined(USE_ESP_IDF)
+#if ESP_IDF_VERSION_MAJOR >= 5
+  wdtc.timeout_ms = CONFIG_ESP_TASK_WDT_TIMEOUT_S * 1000;
+  esp_task_wdt_reconfigure(&wdtc);
+  ESP_LOGV(TAG, "wdt resumed with %d ms timeout", wdtc.timeout_ms);
+#else
+  esp_task_wdt_init(CONFIG_ESP_TASK_WDT_TIMEOUT_S, false);
+  ESP_LOGV(TAG, "wdt resumed with %d seconds timeout", CONFIG_ESP_TASK_WDT_TIMEOUT_S);
+#endif
+#elif defined(USE_ARDUINO)
+  enableLoopWDT();
+  ESP_LOGV(TAG, "wdt resumed");
+#endif
 }
 
 }  // namespace wireguard

--- a/esphome/components/wireguard/wireguard.h
+++ b/esphome/components/wireguard/wireguard.h
@@ -64,6 +64,10 @@ class Wireguard : public PollingComponent {
   void start_connection_();
 };
 
+// These are used for possibly long DNS resolution to temporarily suspend the watchdog
+void suspend_wdt();
+void resume_wdt();
+
 }  // namespace wireguard
 }  // namespace esphome
 


### PR DESCRIPTION
# What does this implement/fix?

The DNS resolution performed when connecting to a WG peer can take longer than the default task watchdog timeout of 5 secs and trigger a panic reboot. This bypasses the watchdog during the call to `esp_wireguard_connect()` in which DNS is resolved. This bypass could possibly be even more granular if it was done in the _esp-wireguard_ library, but this solution keeps the changes in a single repo.

- Arduino -> disables task WDT during DNS resolution (can't change the timeout AFAIK)
- esp-idf -> temporarily extends the timeout to 15 seconds (inspired by `esphome/components/ota/ota_backend_esp_idf.cpp`)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes #3 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
